### PR TITLE
 refactor(eslint-config/core): disable import/prefer-default-export rule

### DIFF
--- a/common/changes/@runespoorstack/eslint-config/refactor-disable-import-prefer-default-export_2024-04-26-08-43.json
+++ b/common/changes/@runespoorstack/eslint-config/refactor-disable-import-prefer-default-export_2024-04-26-08-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@runespoorstack/eslint-config",
+      "comment": "`base-js`, `base-ts`, `react-js`, `react-ts`: <br/>- Disable `import/prefer-default-export` rule due to the frequent eslint disables in the codebases. The decision was made based on the following discussion - [What is the benefit of prefer-default-export?](https://github.com/airbnb/javascript/issues/1365). We have also decided not to disable default exports with `import/no-default-exports` as a lot of default exports might be a part of specification, like storybook configs or any other file-based frameworks.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@runespoorstack/eslint-config"
+}

--- a/eslint/eslint-config/core/base-js.js
+++ b/eslint/eslint-config/core/base-js.js
@@ -22,6 +22,7 @@ module.exports = {
         mjs: 'always'
       }
     ],
+    'import/prefer-default-export': 'off',
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
     'func-names': 'error',

--- a/eslint/eslint-config/core/base-ts.js
+++ b/eslint/eslint-config/core/base-ts.js
@@ -24,6 +24,7 @@ module.exports = {
         mjs: 'always'
       }
     ],
+    'import/prefer-default-export': 'off',
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
     'func-names': 'error',

--- a/eslint/eslint-config/core/react-js.js
+++ b/eslint/eslint-config/core/react-js.js
@@ -51,6 +51,7 @@ module.exports = {
         tsx: 'never'
       }
     ],
+    'import/prefer-default-export': 'off',
     'import/no-extraneous-dependencies': ['error', { peerDependencies: true }],
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',

--- a/eslint/eslint-config/core/react-ts.js
+++ b/eslint/eslint-config/core/react-ts.js
@@ -53,6 +53,7 @@ module.exports = {
         tsx: 'never'
       }
     ],
+    'import/prefer-default-export': 'off',
     'import/no-extraneous-dependencies': ['error', { peerDependencies: true }],
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',


### PR DESCRIPTION
# Pull Request Template

- [x]  Changes were structured by the logical commits/MRs: one logical change - one commit/MR.
- [x]  MR pipeline is green.
- [x]  Tests are added/updated (if relevant).
- [x]  Change are fully described in the MR description.
- [x]  [Impact Analysis](https://dev.to/borysshulyak/impact-analysis-unleashing-the-power-of-understanding-code-dependencies-4ma6) were provided.
- [x]  The related MRs are linked to the current (if relevant).
- [x]  Reviewers are assigned.
- [x]  All the required labels are added. [Read more.](https://github.com/runespoor-engineering/runespoorstack/blob/main/documentation/LABELS.md)

## Glossary

- :white_check_mark: - covered with tests
- :boom: - impacted
- **CodeReview** process - `documentation/CODE_REVIEW.md`

### Detailed description of changes

- `eslint-config` / `base-js`, `base-ts`, `react-js`, `react-ts`: 
  - Disable `import/prefer-default-export` rule due to the frequent eslint disables in the codebases. The decision was made based on the following discussion - [What is the benefit of prefer-default-export?](https://github.com/airbnb/javascript/issues/1365). We have also decided not to disable default exports with `import/no-default-exports` as a lot of default exports might be a part of the specification, like storybook configs or any other file-based frameworks. So if you prefer the default exports, you should add the `'import/prefer-default-export': 'error'` line to your eslint config as it no longer works out of the box.

## Related links

- [What is the benefit of prefer-default-export?](https://github.com/airbnb/javascript/issues/1365)
- https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md
- https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md

## Impact Analysis

### A brief description of the essence of your changes

- `eslint-config/core`: 
  - Disable `import/prefer-default-export` rule due to the frequent eslint disables in the codebases.

### How the system components behaved before your changes. ⬅️

- When there is only a single export from a module, prefer using default export over named export.

### How the system components behave after your changes. ➡️

- No restriction over named/default exports.

### A description of the impact of your changes on the other parts of the system

- If you prefer the default exports, you should add the `'import/prefer-default-export': 'error'` line to your eslint config as it no longer works out of the box;